### PR TITLE
Refactor Discord bot to replace invision functionality with canvas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ go build
 
 # Run with flags
 ./kinshi_vision_bot -dev                        # Development mode (commands prefixed with "dev_")
-./kinshi_vision_bot -invision <command_name>    # Override the slash command name
+./kinshi_vision_bot -canvas <command_name>      # Override the slash command name
 ./kinshi_vision_bot -remove                     # Delete all registered commands on exit
 ```
 
@@ -37,7 +37,7 @@ The application follows a layered architecture with interface-based dependency i
 ```
 Discord Events (discordgo)
     → discord_bot/          — Slash command handling, button interactions
-    → invision_queue/       — Async request queue, processes generations
+    → canvas_queue/         — Async request queue, processes generations
     → stable_diffusion_api/ — HTTP client for the Automatic1111 API
     → repositories/         — Data access (image_generations, default_settings)
     → databases/sqlite/     — SQLite with sequential auto-migrations
@@ -46,7 +46,7 @@ Discord Events (discordgo)
 **Initialization order in `main.go`:** SD API client → SQLite DB (auto-migrates) → repositories → queue → Discord bot → `bot.Start()` (blocks until Ctrl+C).
 
 **Key packages:**
-- `invision_queue/queue.go` (~1282 lines) — core generation logic: queues requests, polls SD API progress, builds responses, handles variations/upscale/reroll
+- `canvas_queue/queue.go` (~1282 lines) — core generation logic: queues requests, polls SD API progress, builds responses, handles variations/upscale/reroll
 - `discord_bot/discord_bot.go` (~710 lines) — registers slash commands, dispatches interaction events to the queue
 - `stable_diffusion_api/` — thin HTTP wrapper for `/sdapi/v1/txt2img`, `/sdapi/v1/upscaler`, and progress endpoints
 - `composite_renderer/` — assembles individual generated images into a 2×2 grid for Discord display
@@ -56,7 +56,7 @@ Discord Events (discordgo)
 
 ## Prompt Parameters
 
-Parameters parsed from the prompt string in `invision_queue/queue.go`:
+Parameters parsed from the prompt string in `canvas_queue/queue.go`:
 - `--ar <w>:<h>` — aspect ratio
 - `--step <n>` — sampling steps
 - `--cfgscale <f>` — CFG scale

--- a/README.md
+++ b/README.md
@@ -53,24 +53,24 @@ Before running the bot, configure an `.env` file to specify your bot’s details
 ### Notes
 
 - On the first run, a SQLite database file will be generated in the same directory as the bot.
-- Use the `-invision <new command name>` option to avoid conflicts with other bots.
+- Use the `-canvas <new command name>` option to avoid conflicts with other bots.
 
 ---
 
 ## Commands
 
-### `/invision_settings`
+### `/canvas_settings`
 
-Displays buttons in Discord to update default settings for the `/invision` command.  
+Displays buttons in Discord to update default settings for the `/canvas` command.
 
-![Invision Settings](https://user-images.githubusercontent.com/7525989/211077599-482536ef-1a70-4f58-abf0-314c773c64c6.png)
+![Canvas Settings](https://user-images.githubusercontent.com/7525989/211077599-482536ef-1a70-4f58-abf0-314c773c64c6.png)
 
-### `/invision`
+### `/canvas`
 
 Generates an image based on a text prompt. Example:
 
 ```bash
-/invision cute kitten riding a skateboard
+/canvas cute kitten riding a skateboard
 ```
 
 #### Options
@@ -78,7 +78,7 @@ Generates an image based on a text prompt. Example:
 - Specify Aspect Ratio:
 
   ```bash
-  /invision cute kitten --ar 16:9
+  /canvas cute kitten --ar 16:9
   ```
 
 ---

--- a/canvas_queue/interface.go
+++ b/canvas_queue/interface.go
@@ -1,4 +1,4 @@
-package invision_queue
+package canvas_queue
 
 import (
 	"kinshi_vision_bot/entities"
@@ -7,7 +7,7 @@ import (
 )
 
 type Queue interface {
-	AddInvision(item *QueueItem) (int, error)
+	AddCanvas(item *QueueItem) (int, error)
 	StartPolling(botSession *discordgo.Session)
 	GetBotDefaultSettings() (*entities.DefaultSettings, error)
 	UpdateDefaultDimensions(width, height int) (*entities.DefaultSettings, error)

--- a/canvas_queue/queue.go
+++ b/canvas_queue/queue.go
@@ -1,4 +1,4 @@
-package invision_queue
+package canvas_queue
 
 import (
 	"bytes"
@@ -38,7 +38,7 @@ type queueImpl struct {
 	botSession          *discordgo.Session
 	stableDiffusionAPI  stable_diffusion_api.StableDiffusionAPI
 	queue               chan *QueueItem
-	currentInvision     *QueueItem
+	currentCanvas       *QueueItem
 	mu                  sync.Mutex
 	imageGenerationRepo image_generations.Repository
 	compositeRenderer   composite_renderer.Renderer
@@ -85,7 +85,7 @@ func New(cfg Config) (Queue, error) {
 type ItemType int
 
 const (
-	ItemTypeInvision ItemType = iota
+	ItemTypeCanvas ItemType = iota
 	ItemTypeReroll
 	ItemTypeUpscale
 	ItemTypeVariation
@@ -102,7 +102,7 @@ type QueueItem struct {
 	DiscordInteraction *discordgo.Interaction
 }
 
-func (q *queueImpl) AddInvision(item *QueueItem) (int, error) {
+func (q *queueImpl) AddCanvas(item *QueueItem) (int, error) {
 	q.queue <- item
 
 	linePosition := len(q.queue)
@@ -134,7 +134,7 @@ func (q *queueImpl) StartPolling(botSession *discordgo.Session) {
 		case <-stop:
 			stopPolling = true
 		case <-time.After(1 * time.Second):
-			if q.currentInvision == nil {
+			if q.currentCanvas == nil {
 				q.pullNextInQueue()
 			}
 		}
@@ -154,9 +154,9 @@ func (q *queueImpl) pullNextInQueue() {
 		q.mu.Lock()
 		defer q.mu.Unlock()
 
-		q.currentInvision = element
+		q.currentCanvas = element
 
-		q.processCurrentInvision()
+		q.processCurrentCanvas()
 	}
 }
 
@@ -566,17 +566,17 @@ func extractPixelFromPrompt(prompt string, defaultXYValue int) (*pixelSpecifiedR
 	}, nil
 }
 
-func (q *queueImpl) processCurrentInvision() {
+func (q *queueImpl) processCurrentCanvas() {
 	go func() {
 		defer func() {
 			q.mu.Lock()
 			defer q.mu.Unlock()
 
-			q.currentInvision = nil
+			q.currentCanvas = nil
 		}()
 
-		if q.currentInvision.Type == ItemTypeUpscale {
-			q.processUpscaleInvision(q.currentInvision)
+		if q.currentCanvas.Type == ItemTypeUpscale {
+			q.processUpscaleCanvas(q.currentCanvas)
 
 			return
 		}
@@ -603,25 +603,25 @@ func (q *queueImpl) processCurrentInvision() {
 			}
 			return strings.TrimSpace(s)
 		}
-		q.currentInvision.Prompt = scrubText(q.currentInvision.Prompt)
-		q.currentInvision.NegativePrompt = scrubText(q.currentInvision.NegativePrompt)
+		q.currentCanvas.Prompt = scrubText(q.currentCanvas.Prompt)
+		q.currentCanvas.NegativePrompt = scrubText(q.currentCanvas.NegativePrompt)
 
 		// add optional parameter: Negative prompt — always prepend safety terms
 		safetyNegative := strings.Join(q.blockedKeywords, ", ")
 		negativePrompt := safetyNegative
-		if q.currentInvision.NegativePrompt != "" {
-			negativePrompt = safetyNegative + ", " + q.currentInvision.NegativePrompt
+		if q.currentCanvas.NegativePrompt != "" {
+			negativePrompt = safetyNegative + ", " + q.currentCanvas.NegativePrompt
 		}
 
 		// add optional parameter: sampler
 		samplerName1 := ""
-		if q.currentInvision.SamplerName1 == "" {
+		if q.currentCanvas.SamplerName1 == "" {
 			samplerName1 = "DPM++ 2M"
 		} else {
-			samplerName1 = q.currentInvision.SamplerName1
+			samplerName1 = q.currentCanvas.SamplerName1
 		}
 
-		promptRes, err := extractDimensionsFromPrompt(q.currentInvision.Prompt, defaultWidth, defaultHeight)
+		promptRes, err := extractDimensionsFromPrompt(q.currentCanvas.Prompt, defaultWidth, defaultHeight)
 		if err != nil {
 			log.Printf("Error extracting dimensions from prompt: %v", err)
 
@@ -664,7 +664,7 @@ func (q *queueImpl) processCurrentInvision() {
 			return
 		}
 
-		enableHR1 = q.currentInvision.UseHiresFix
+		enableHR1 = q.currentCanvas.UseHiresFix
 		if enableHR1 {
 			upscaleRate1 = promptResZ.ZoomScale
 			upscalerName1 = "Latent"
@@ -713,7 +713,7 @@ func (q *queueImpl) processCurrentInvision() {
 			NegativePrompt:    negativePrompt,
 			Width:             scaledWidth,
 			Height:            scaledHeight,
-			RestoreFaces:      q.currentInvision.RestoreFaces,
+			RestoreFaces:      q.currentCanvas.RestoreFaces,
 			EnableHR:          enableHR1,
 			HRUpscaleRate:     upscaleRate1,
 			HRUpscaler:        upscalerName1,
@@ -729,8 +729,8 @@ func (q *queueImpl) processCurrentInvision() {
 			Processed:         false,
 		}
 
-		if q.currentInvision.Type == ItemTypeReroll || q.currentInvision.Type == ItemTypeVariation {
-			foundGeneration, err := q.getPreviousGeneration(q.currentInvision, q.currentInvision.InteractionIndex)
+		if q.currentCanvas.Type == ItemTypeReroll || q.currentCanvas.Type == ItemTypeVariation {
+			foundGeneration, err := q.getPreviousGeneration(q.currentCanvas, q.currentCanvas.InteractionIndex)
 			if err != nil {
 				log.Printf("Error getting prompt for reroll: %v", err)
 
@@ -744,26 +744,26 @@ func (q *queueImpl) processCurrentInvision() {
 			newGeneration.Subseed = -1
 
 			// for variations, the subseed strength determines how much variation we get
-			if q.currentInvision.Type == ItemTypeVariation {
+			if q.currentCanvas.Type == ItemTypeVariation {
 				newGeneration.SubseedStrength = 0.15
 			}
 		}
 
-		err = q.processInvisionGrid(newGeneration, q.currentInvision)
+		err = q.processCanvasGrid(newGeneration, q.currentCanvas)
 		if err != nil {
-			log.Printf("Error processing invision grid: %v", err)
+			log.Printf("Error processing canvas grid: %v", err)
 
 			return
 		}
 	}()
 }
 
-func (q *queueImpl) getPreviousGeneration(invision *QueueItem, sortOrder int) (*entities.ImageGeneration, error) {
-	interactionID := invision.DiscordInteraction.ID
+func (q *queueImpl) getPreviousGeneration(canvas *QueueItem, sortOrder int) (*entities.ImageGeneration, error) {
+	interactionID := canvas.DiscordInteraction.ID
 	messageID := ""
 
-	if invision.DiscordInteraction.Message != nil {
-		messageID = invision.DiscordInteraction.Message.ID
+	if canvas.DiscordInteraction.Message != nil {
+		messageID = canvas.DiscordInteraction.Message.ID
 	}
 
 	log.Printf("Reimagining interaction: %v, Message: %v", interactionID, messageID)
@@ -780,9 +780,9 @@ func (q *queueImpl) getPreviousGeneration(invision *QueueItem, sortOrder int) (*
 	return generation, nil
 }
 
-func invisionMessageContent(generation *entities.ImageGeneration, user *discordgo.User, progress float64) string {
+func canvasMessageContent(generation *entities.ImageGeneration, user *discordgo.User, progress float64) string {
 	if progress >= 0 && progress < 1 {
-		return fmt.Sprintf("<@%s> asked me to invision \"%s\". Currently dreaming it up for them. Progress: %.0f%%",
+		return fmt.Sprintf("<@%s> asked me to paint \"%s\". My brushstrokes are taking shape... %.0f%%",
 			user.ID, generation.Prompt, progress*100)
 	} else {
 		seedString := fmt.Sprintf("%d", generation.Seed)
@@ -801,7 +801,7 @@ func invisionMessageContent(generation *entities.ImageGeneration, user *discordg
 				generation.Width,
 				generation.Height)
 		}
-		return fmt.Sprintf("<@%s> asked me to invision \"%s\" at step %d cfgscale %s seed %s with sampler %s. resolution: %s. here is what I invisiond for them.",
+		return fmt.Sprintf("<@%s> asked me to paint \"%s\". step %d · cfgscale %s · seed %s · sampler %s · %s. Here is what I painted for them.",
 			user.ID,
 			generation.Prompt,
 			generation.Steps,
@@ -813,12 +813,12 @@ func invisionMessageContent(generation *entities.ImageGeneration, user *discordg
 	}
 }
 
-func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration, invision *QueueItem) error {
-	log.Printf("Processing invision #%s: %v\n", invision.DiscordInteraction.ID, newGeneration.Prompt)
+func (q *queueImpl) processCanvasGrid(newGeneration *entities.ImageGeneration, canvas *QueueItem) error {
+	log.Printf("Processing canvas #%s: %v\n", canvas.DiscordInteraction.ID, newGeneration.Prompt)
 
-	newContent := invisionMessageContent(newGeneration, invision.DiscordInteraction.Member.User, 0)
+	newContent := canvasMessageContent(newGeneration, canvas.DiscordInteraction.Member.User, 0)
 
-	message, err := q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+	message, err := q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 		Content: &newContent,
 	})
 	if err != nil {
@@ -839,9 +839,9 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 		return err
 	}
 
-	newGeneration.InteractionID = invision.DiscordInteraction.ID
+	newGeneration.InteractionID = canvas.DiscordInteraction.ID
 	newGeneration.MessageID = message.ID
-	newGeneration.MemberID = invision.DiscordInteraction.Member.User.ID
+	newGeneration.MemberID = canvas.DiscordInteraction.Member.User.ID
 	newGeneration.SortOrder = 0
 	newGeneration.BatchCount = defaultBatchCount
 	newGeneration.BatchSize = defaultBatchSize
@@ -871,9 +871,9 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 					continue
 				}
 
-				progressContent := invisionMessageContent(newGeneration, invision.DiscordInteraction.Member.User, progress.Progress)
+				progressContent := canvasMessageContent(newGeneration, canvas.DiscordInteraction.Member.User, progress.Progress)
 
-				_, progressErr = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+				_, progressErr = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 					Content: &progressContent,
 				})
 				if progressErr != nil {
@@ -907,9 +907,9 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 	if err != nil {
 		log.Printf("Error processing image: %v\n", err)
 
-		errorContent := "I'm sorry, but I had a problem imagining your image."
+		errorContent := "My brushstroke faltered... I couldn't paint this one. Please try again."
 
-		_, err = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+		_, err = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 			Content: &errorContent,
 		})
 
@@ -918,7 +918,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 
 	generationDone <- true
 
-	finishedContent := invisionMessageContent(newGeneration, invision.DiscordInteraction.Member.User, 1)
+	finishedContent := canvasMessageContent(newGeneration, canvas.DiscordInteraction.Member.User, 1)
 
 	log.Printf("Seeds: %v Subseeds:%v", resp.Seeds, resp.Subseeds)
 
@@ -976,13 +976,13 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 		return err
 	}
 
-	_, err = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+	_, err = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 		Content: &finishedContent,
 		Files: []*discordgo.File{
 			{
 				ContentType: "image/png",
 				// append timestamp for grid image result
-				Name:   "invision_" + time.Now().Format("20060102150405") + ".png",
+				Name:   "canvas_" + time.Now().Format("20060102150405") + ".png",
 				Reader: compositeImage,
 			},
 		},
@@ -997,7 +997,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_variation_1",
+						CustomID: "canvas_variation_1",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "♻️",
 						},
@@ -1010,7 +1010,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_variation_2",
+						CustomID: "canvas_variation_2",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "♻️",
 						},
@@ -1023,7 +1023,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_variation_3",
+						CustomID: "canvas_variation_3",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "♻️",
 						},
@@ -1036,7 +1036,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_variation_4",
+						CustomID: "canvas_variation_4",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "♻️",
 						},
@@ -1049,7 +1049,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_reroll",
+						CustomID: "canvas_reroll",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "🎲",
 						},
@@ -1066,7 +1066,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_upscale_1",
+						CustomID: "canvas_upscale_1",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "⬆️",
 						},
@@ -1079,7 +1079,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_upscale_2",
+						CustomID: "canvas_upscale_2",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "⬆️",
 						},
@@ -1092,7 +1092,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_upscale_3",
+						CustomID: "canvas_upscale_3",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "⬆️",
 						},
@@ -1105,7 +1105,7 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 						// Disabled allows bot to disable some buttons for users.
 						Disabled: false,
 						// CustomID is a thing telling Discord which data to send when this button will be pressed.
-						CustomID: "invision_upscale_4",
+						CustomID: "canvas_upscale_4",
 						Emoji: &discordgo.ComponentEmoji{
 							Name: "⬆️",
 						},
@@ -1126,29 +1126,29 @@ func (q *queueImpl) processInvisionGrid(newGeneration *entities.ImageGeneration,
 func upscaleMessageContent(user *discordgo.User, fetchProgress, upscaleProgress float64) string {
 	if fetchProgress >= 0 && fetchProgress <= 1 && upscaleProgress < 1 {
 		if upscaleProgress == 0 {
-			return fmt.Sprintf("Currently upscaling the image for you... Fetch progress: %.0f%%", fetchProgress*100)
+			return fmt.Sprintf("Refining every detail on the canvas... %.0f%%", fetchProgress*100)
 		} else {
-			return fmt.Sprintf("Currently upscaling the image for you... Fetch progress: %.0f%% Upscale progress: %.0f%%",
+			return fmt.Sprintf("Refining every detail on the canvas... %.0f%% · Upscale: %.0f%%",
 				fetchProgress*100, upscaleProgress*100)
 		}
 	} else {
-		return fmt.Sprintf("<@%s> asked me to upscale their image. Here's the result:",
+		return fmt.Sprintf("<@%s> asked me to refine their painting. Here it is:",
 			user.ID)
 	}
 }
 
-func (q *queueImpl) processUpscaleInvision(invision *QueueItem) {
-	interactionID := invision.DiscordInteraction.ID
+func (q *queueImpl) processUpscaleCanvas(canvas *QueueItem) {
+	interactionID := canvas.DiscordInteraction.ID
 	messageID := ""
 
-	if invision.DiscordInteraction.Message != nil {
-		messageID = invision.DiscordInteraction.Message.ID
+	if canvas.DiscordInteraction.Message != nil {
+		messageID = canvas.DiscordInteraction.Message.ID
 	}
 
 	log.Printf("Upscaling image: %v, Message: %v, Upscale Index: %d",
-		interactionID, messageID, invision.InteractionIndex)
+		interactionID, messageID, canvas.InteractionIndex)
 
-	generation, err := q.imageGenerationRepo.GetByMessageAndSort(context.Background(), messageID, invision.InteractionIndex)
+	generation, err := q.imageGenerationRepo.GetByMessageAndSort(context.Background(), messageID, canvas.InteractionIndex)
 	if err != nil {
 		log.Printf("Error getting image generation: %v", err)
 
@@ -1157,9 +1157,9 @@ func (q *queueImpl) processUpscaleInvision(invision *QueueItem) {
 
 	log.Printf("Found generation: %v", generation)
 
-	newContent := upscaleMessageContent(invision.DiscordInteraction.Member.User, 0, 0)
+	newContent := upscaleMessageContent(canvas.DiscordInteraction.Member.User, 0, 0)
 
-	_, err = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+	_, err = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 		Content: &newContent,
 	})
 	if err != nil {
@@ -1198,9 +1198,9 @@ func (q *queueImpl) processUpscaleInvision(invision *QueueItem) {
 
 				lastProgress = progress.Progress
 
-				progressContent := upscaleMessageContent(invision.DiscordInteraction.Member.User, fetchProgress, upscaleProgress)
+				progressContent := upscaleMessageContent(canvas.DiscordInteraction.Member.User, fetchProgress, upscaleProgress)
 
-				_, progressErr = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+				_, progressErr = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 					Content: &progressContent,
 				})
 				if progressErr != nil {
@@ -1241,7 +1241,7 @@ func (q *queueImpl) processUpscaleInvision(invision *QueueItem) {
 
 		errorContent := "I'm sorry, but I had a problem upscaling your image."
 
-		_, err = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+		_, err = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 			Content: &errorContent,
 		})
 
@@ -1260,19 +1260,19 @@ func (q *queueImpl) processUpscaleInvision(invision *QueueItem) {
 	imageBuf := bytes.NewBuffer(decodedImage)
 
 	log.Printf("Successfully upscaled image: %v, Message: %v, Upscale Index: %d",
-		interactionID, messageID, invision.InteractionIndex)
+		interactionID, messageID, canvas.InteractionIndex)
 
-	finishedContent := fmt.Sprintf("<@%s> asked me to upscale their image. (seed: %d) Here's the result:",
-		invision.DiscordInteraction.Member.User.ID,
+	finishedContent := fmt.Sprintf("<@%s> asked me to refine their painting. (seed: %d) Here it is:",
+		canvas.DiscordInteraction.Member.User.ID,
 		generation.Seed)
 
-	_, err = q.botSession.InteractionResponseEdit(invision.DiscordInteraction, &discordgo.WebhookEdit{
+	_, err = q.botSession.InteractionResponseEdit(canvas.DiscordInteraction, &discordgo.WebhookEdit{
 		Content: &finishedContent,
 		Files: []*discordgo.File{
 			{
 				ContentType: "image/png",
 				// add timestamp to output file
-				Name:   "invision_" + time.Now().Format("20060102150405") + ".png",
+				Name:   "canvas_" + time.Now().Format("20060102150405") + ".png",
 				Reader: imageBuf,
 			},
 		},

--- a/discord_bot/discord_bot.go
+++ b/discord_bot/discord_bot.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"kinshi_vision_bot/entities"
-	"kinshi_vision_bot/invision_queue"
+	"kinshi_vision_bot/canvas_queue"
 	"log"
 	"strconv"
 	"strings"
@@ -16,9 +16,9 @@ type botImpl struct {
 	developmentMode    bool
 	botSession         *discordgo.Session
 	guildID            string
-	invisionQueue      invision_queue.Queue
+	canvasQueue        canvas_queue.Queue
 	registeredCommands []*discordgo.ApplicationCommand
-	invisionCommand    string
+	canvasCommand      string
 	removeCommands     bool
 }
 
@@ -26,25 +26,25 @@ type Config struct {
 	DevelopmentMode bool
 	BotToken        string
 	GuildID         string
-	InvisionQueue   invision_queue.Queue
-	InvisionCommand string
+	CanvasQueue   canvas_queue.Queue
+	CanvasCommand string
 	RemoveCommands  bool
 }
 
-func (b *botImpl) invisionCommandString() string {
+func (b *botImpl) canvasCommandString() string {
 	if b.developmentMode {
-		return "dev_" + b.invisionCommand
+		return "dev_" + b.canvasCommand
 	}
 
-	return b.invisionCommand
+	return b.canvasCommand
 }
 
-func (b *botImpl) invisionSettingsCommandString() string {
+func (b *botImpl) canvasSettingsCommandString() string {
 	if b.developmentMode {
-		return "dev_" + b.invisionCommand + "_settings"
+		return "dev_" + b.canvasCommand + "_settings"
 	}
 
-	return b.invisionCommand + "_settings"
+	return b.canvasCommand + "_settings"
 }
 
 func New(cfg Config) (Bot, error) {
@@ -56,12 +56,12 @@ func New(cfg Config) (Bot, error) {
 		return nil, errors.New("missing guild ID")
 	}
 
-	if cfg.InvisionQueue == nil {
-		return nil, errors.New("missing invision queue")
+	if cfg.CanvasQueue == nil {
+		return nil, errors.New("missing canvas queue")
 	}
 
-	if cfg.InvisionCommand == "" {
-		return nil, errors.New("missing invision command")
+	if cfg.CanvasCommand == "" {
+		return nil, errors.New("missing canvas command")
 	}
 
 	botSession, err := discordgo.New("Bot " + cfg.BotToken)
@@ -80,9 +80,9 @@ func New(cfg Config) (Bot, error) {
 	bot := &botImpl{
 		developmentMode:    cfg.DevelopmentMode,
 		botSession:         botSession,
-		invisionQueue:      cfg.InvisionQueue,
+		canvasQueue:        cfg.CanvasQueue,
 		registeredCommands: make([]*discordgo.ApplicationCommand, 0),
-		invisionCommand:    cfg.InvisionCommand,
+		canvasCommand:      cfg.CanvasCommand,
 		removeCommands:     cfg.RemoveCommands,
 	}
 
@@ -90,12 +90,12 @@ func New(cfg Config) (Bot, error) {
 		log.Printf("Warning: could not clean up stale commands (bot may need applications.commands scope): %v", err)
 	}
 
-	err = bot.addInvisionCommand()
+	err = bot.addCanvasCommand()
 	if err != nil {
 		return nil, err
 	}
 
-	err = bot.addInvisionSettingsCommand()
+	err = bot.addCanvasSettingsCommand()
 	if err != nil {
 		return nil, err
 	}
@@ -104,19 +104,19 @@ func New(cfg Config) (Bot, error) {
 		switch i.Type {
 		case discordgo.InteractionApplicationCommand:
 			switch i.ApplicationCommandData().Name {
-			case bot.invisionCommandString():
-				bot.processInvisionCommand(s, i)
-			case bot.invisionSettingsCommandString():
-				bot.processInvisionSettingsCommand(s, i)
+			case bot.canvasCommandString():
+				bot.processCanvasCommand(s, i)
+			case bot.canvasSettingsCommandString():
+				bot.processCanvasSettingsCommand(s, i)
 			default:
 				log.Printf("Unknown command '%v'", i.ApplicationCommandData().Name)
 			}
 		case discordgo.InteractionMessageComponent:
 			switch customID := i.MessageComponentData().CustomID; {
-			case customID == "invision_reroll":
-				bot.processInvisionReroll(s, i)
-			case strings.HasPrefix(customID, "invision_upscale_"):
-				interactionIndex := strings.TrimPrefix(customID, "invision_upscale_")
+			case customID == "canvas_reroll":
+				bot.processCanvasReroll(s, i)
+			case strings.HasPrefix(customID, "canvas_upscale_"):
+				interactionIndex := strings.TrimPrefix(customID, "canvas_upscale_")
 
 				interactionIndexInt, intErr := strconv.Atoi(interactionIndex)
 				if intErr != nil {
@@ -125,9 +125,9 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				bot.processInvisionUpscale(s, i, interactionIndexInt)
-			case strings.HasPrefix(customID, "invision_variation_"):
-				interactionIndex := strings.TrimPrefix(customID, "invision_variation_")
+				bot.processCanvasUpscale(s, i, interactionIndexInt)
+			case strings.HasPrefix(customID, "canvas_variation_"):
+				interactionIndex := strings.TrimPrefix(customID, "canvas_variation_")
 
 				interactionIndexInt, intErr := strconv.Atoi(interactionIndex)
 				if intErr != nil {
@@ -136,10 +136,10 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				bot.processInvisionVariation(s, i, interactionIndexInt)
-			case customID == "invision_dimension_setting_menu":
+				bot.processCanvasVariation(s, i, interactionIndexInt)
+			case customID == "canvas_dimension_setting_menu":
 				if len(i.MessageComponentData().Values) == 0 {
-					log.Printf("No values for invision dimension setting menu")
+					log.Printf("No values for canvas dimension setting menu")
 
 					return
 				}
@@ -163,12 +163,12 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				bot.processInvisionDimensionSetting(s, i, widthInt, heightInt)
+				bot.processCanvasDimensionSetting(s, i, widthInt, heightInt)
 
 			// patch from upstream
-			case customID == "invision_batch_count_setting_menu":
+			case customID == "canvas_batch_count_setting_menu":
 				if len(i.MessageComponentData().Values) == 0 {
-					log.Printf("No values for invision batch count setting menu")
+					log.Printf("No values for canvas batch count setting menu")
 
 					return
 				}
@@ -198,10 +198,10 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				bot.processInvisionBatchSetting(s, i, batchCountInt, batchSizeInt)
-			case customID == "invision_batch_size_setting_menu":
+				bot.processCanvasBatchSetting(s, i, batchCountInt, batchSizeInt)
+			case customID == "canvas_batch_size_setting_menu":
 				if len(i.MessageComponentData().Values) == 0 {
-					log.Printf("No values for invision batch count setting menu")
+					log.Printf("No values for canvas batch count setting menu")
 
 					return
 				}
@@ -231,7 +231,7 @@ func New(cfg Config) (Bot, error) {
 					return
 				}
 
-				bot.processInvisionBatchSetting(s, i, batchCountInt, batchSizeInt)
+				bot.processCanvasBatchSetting(s, i, batchCountInt, batchSizeInt)
 
 			default:
 				log.Printf("Unknown message component '%v'", i.MessageComponentData().CustomID)
@@ -243,7 +243,7 @@ func New(cfg Config) (Bot, error) {
 }
 
 func (b *botImpl) Start() {
-	b.invisionQueue.StartPolling(b.botSession)
+	b.canvasQueue.StartPolling(b.botSession)
 
 	err := b.teardown()
 	if err != nil {
@@ -276,8 +276,8 @@ func (b *botImpl) cleanupStaleCommands() error {
 	}
 
 	keep := map[string]bool{
-		b.invisionCommandString():         true,
-		b.invisionSettingsCommandString(): true,
+		b.canvasCommandString():         true,
+		b.canvasSettingsCommandString(): true,
 	}
 
 	for _, cmd := range existing {
@@ -293,17 +293,17 @@ func (b *botImpl) cleanupStaleCommands() error {
 	return nil
 }
 
-func (b *botImpl) addInvisionCommand() error {
-	log.Printf("Adding command '%s'...", b.invisionCommandString())
+func (b *botImpl) addCanvasCommand() error {
+	log.Printf("Adding command '%s'...", b.canvasCommandString())
 
 	cmd, err := b.botSession.ApplicationCommandCreate(b.botSession.State.User.ID, b.guildID, &discordgo.ApplicationCommand{
-		Name:        b.invisionCommandString(),
-		Description: "Ask the bot to invision something",
+		Name:        b.canvasCommandString(),
+		Description: "Ask Maëlle to paint something",
 		Options: []*discordgo.ApplicationCommandOption{
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "prompt",
-				Description: "The text prompt to invision",
+				Description: "The text prompt to paint",
 				Required:    true,
 			},
 			{
@@ -435,7 +435,7 @@ func (b *botImpl) addInvisionCommand() error {
 		},
 	})
 	if err != nil {
-		log.Printf("Error creating '%s' command: %v", b.invisionCommandString(), err)
+		log.Printf("Error creating '%s' command: %v", b.canvasCommandString(), err)
 
 		return err
 	}
@@ -445,15 +445,15 @@ func (b *botImpl) addInvisionCommand() error {
 	return nil
 }
 
-func (b *botImpl) addInvisionSettingsCommand() error {
-	log.Printf("Adding command '%s'...", b.invisionSettingsCommandString())
+func (b *botImpl) addCanvasSettingsCommand() error {
+	log.Printf("Adding command '%s'...", b.canvasSettingsCommandString())
 
 	cmd, err := b.botSession.ApplicationCommandCreate(b.botSession.State.User.ID, b.guildID, &discordgo.ApplicationCommand{
-		Name:        b.invisionSettingsCommandString(),
-		Description: "Change the default settings for the invision command",
+		Name:        b.canvasSettingsCommandString(),
+		Description: "Change the default settings for the canvas command",
 	})
 	if err != nil {
-		log.Printf("Error creating '%s' command: %v", b.invisionSettingsCommandString(), err)
+		log.Printf("Error creating '%s' command: %v", b.canvasSettingsCommandString(), err)
 
 		return err
 	}
@@ -463,19 +463,19 @@ func (b *botImpl) addInvisionSettingsCommand() error {
 	return nil
 }
 
-func (b *botImpl) processInvisionReroll(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	position, queueError := b.invisionQueue.AddInvision(&invision_queue.QueueItem{
-		Type:               invision_queue.ItemTypeReroll,
+func (b *botImpl) processCanvasReroll(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	position, queueError := b.canvasQueue.AddCanvas(&canvas_queue.QueueItem{
+		Type:               canvas_queue.ItemTypeReroll,
 		DiscordInteraction: i.Interaction,
 	})
 	if queueError != nil {
-		log.Printf("Error adding invision to queue: %v\n", queueError)
+		log.Printf("Error adding to canvas queue: %v\n", queueError)
 	}
 
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("I'm reimagining that for you... You are currently #%d in line.", position),
+			Content: fmt.Sprintf("My brush finds new paths... You are #%d in the queue.", position),
 		},
 	})
 	if err != nil {
@@ -483,20 +483,20 @@ func (b *botImpl) processInvisionReroll(s *discordgo.Session, i *discordgo.Inter
 	}
 }
 
-func (b *botImpl) processInvisionUpscale(s *discordgo.Session, i *discordgo.InteractionCreate, upscaleIndex int) {
-	position, queueError := b.invisionQueue.AddInvision(&invision_queue.QueueItem{
-		Type:               invision_queue.ItemTypeUpscale,
+func (b *botImpl) processCanvasUpscale(s *discordgo.Session, i *discordgo.InteractionCreate, upscaleIndex int) {
+	position, queueError := b.canvasQueue.AddCanvas(&canvas_queue.QueueItem{
+		Type:               canvas_queue.ItemTypeUpscale,
 		InteractionIndex:   upscaleIndex,
 		DiscordInteraction: i.Interaction,
 	})
 	if queueError != nil {
-		log.Printf("Error adding invision to queue: %v\n", queueError)
+		log.Printf("Error adding to canvas queue: %v\n", queueError)
 	}
 
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("I'm upscaling that for you... You are currently #%d in line.", position),
+			Content: fmt.Sprintf("I'll bring more detail to the canvas... You are #%d in the queue.", position),
 		},
 	})
 	if err != nil {
@@ -504,20 +504,20 @@ func (b *botImpl) processInvisionUpscale(s *discordgo.Session, i *discordgo.Inte
 	}
 }
 
-func (b *botImpl) processInvisionVariation(s *discordgo.Session, i *discordgo.InteractionCreate, variationIndex int) {
-	position, queueError := b.invisionQueue.AddInvision(&invision_queue.QueueItem{
-		Type:               invision_queue.ItemTypeVariation,
+func (b *botImpl) processCanvasVariation(s *discordgo.Session, i *discordgo.InteractionCreate, variationIndex int) {
+	position, queueError := b.canvasQueue.AddCanvas(&canvas_queue.QueueItem{
+		Type:               canvas_queue.ItemTypeVariation,
 		InteractionIndex:   variationIndex,
 		DiscordInteraction: i.Interaction,
 	})
 	if queueError != nil {
-		log.Printf("Error adding invision to queue: %v\n", queueError)
+		log.Printf("Error adding to canvas queue: %v\n", queueError)
 	}
 
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("I'm imagining more variations for you... You are currently #%d in line.", position),
+			Content: fmt.Sprintf("Let me explore other strokes of this vision... You are #%d in the queue.", position),
 		},
 	})
 	if err != nil {
@@ -525,7 +525,7 @@ func (b *botImpl) processInvisionVariation(s *discordgo.Session, i *discordgo.In
 	}
 }
 
-func (b *botImpl) processInvisionCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (b *botImpl) processCanvasCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	options := i.ApplicationCommandData().Options
 
 	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
@@ -560,17 +560,17 @@ func (b *botImpl) processInvisionCommand(s *discordgo.Session, i *discordgo.Inte
 			restoreFaces, _ = strconv.ParseBool(rf.StringValue())
 		}
 
-		position, queueError = b.invisionQueue.AddInvision(&invision_queue.QueueItem{
+		position, queueError = b.canvasQueue.AddCanvas(&canvas_queue.QueueItem{
 			Prompt:             prompt,
 			NegativePrompt:     negative,
 			SamplerName1:       sampler,
-			Type:               invision_queue.ItemTypeInvision,
+			Type:               canvas_queue.ItemTypeCanvas,
 			UseHiresFix:        hiresfix,
 			RestoreFaces:       restoreFaces,
 			DiscordInteraction: i.Interaction,
 		})
 		if queueError != nil {
-			log.Printf("Error adding invision to queue: %v\n", queueError)
+			log.Printf("Error adding to canvas queue: %v\n", queueError)
 		}
 	}
 
@@ -578,11 +578,10 @@ func (b *botImpl) processInvisionCommand(s *discordgo.Session, i *discordgo.Inte
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Content: fmt.Sprintf(
-				"I'm dreaming something up for you. You are currently #%d in line.\n<@%s> asked me to invision \"%s\", with sampler: %s",
+				"My brush is ready... You are #%d in the queue.\n<@%s> asked me to paint \"%s\".",
 				position,
 				i.Member.User.ID,
-				prompt,
-				sampler),
+				prompt),
 		},
 	})
 	if err != nil {
@@ -598,7 +597,7 @@ func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.M
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.SelectMenu{
-					CustomID:  "invision_dimension_setting_menu",
+					CustomID:  "canvas_dimension_setting_menu",
 					MinValues: &minValues,
 					MaxValues: 1,
 					Options: []discordgo.SelectMenuOption{
@@ -619,7 +618,7 @@ func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.M
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.SelectMenu{
-					CustomID:  "invision_batch_count_setting_menu",
+					CustomID:  "canvas_batch_count_setting_menu",
 					MinValues: &minValues,
 					MaxValues: 1,
 					Options: []discordgo.SelectMenuOption{
@@ -645,7 +644,7 @@ func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.M
 		discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.SelectMenu{
-					CustomID:  "invision_batch_size_setting_menu",
+					CustomID:  "canvas_batch_size_setting_menu",
 					MinValues: &minValues,
 					MaxValues: 1,
 					Options: []discordgo.SelectMenuOption{
@@ -671,8 +670,8 @@ func settingsMessageComponents(settings *entities.DefaultSettings) []discordgo.M
 	}
 }
 
-func (b *botImpl) processInvisionSettingsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	botSettings, err := b.invisionQueue.GetBotDefaultSettings()
+func (b *botImpl) processCanvasSettingsCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	botSettings, err := b.canvasQueue.GetBotDefaultSettings()
 	if err != nil {
 		log.Printf("error getting default settings for settings command: %v", err)
 
@@ -685,7 +684,7 @@ func (b *botImpl) processInvisionSettingsCommand(s *discordgo.Session, i *discor
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Title:      "Settings",
-			Content:    "Choose defaults settings for the invision command:",
+			Content:    "Choose defaults settings for the canvas command:",
 			Components: messageComponents,
 		},
 	})
@@ -694,8 +693,8 @@ func (b *botImpl) processInvisionSettingsCommand(s *discordgo.Session, i *discor
 	}
 }
 
-func (b *botImpl) processInvisionDimensionSetting(s *discordgo.Session, i *discordgo.InteractionCreate, height, width int) {
-	botSettings, err := b.invisionQueue.UpdateDefaultDimensions(width, height)
+func (b *botImpl) processCanvasDimensionSetting(s *discordgo.Session, i *discordgo.InteractionCreate, height, width int) {
+	botSettings, err := b.canvasQueue.UpdateDefaultDimensions(width, height)
 	if err != nil {
 		log.Printf("error updating default dimensions: %v", err)
 
@@ -717,7 +716,7 @@ func (b *botImpl) processInvisionDimensionSetting(s *discordgo.Session, i *disco
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
-			Content:    "Choose defaults settings for the invision command:",
+			Content:    "Choose defaults settings for the canvas command:",
 			Components: messageComponents,
 		},
 	})
@@ -726,8 +725,8 @@ func (b *botImpl) processInvisionDimensionSetting(s *discordgo.Session, i *disco
 	}
 }
 
-func (b *botImpl) processInvisionBatchSetting(s *discordgo.Session, i *discordgo.InteractionCreate, batchCount, batchSize int) {
-	botSettings, err := b.invisionQueue.UpdateDefaultBatch(batchCount, batchSize)
+func (b *botImpl) processCanvasBatchSetting(s *discordgo.Session, i *discordgo.InteractionCreate, batchCount, batchSize int) {
+	botSettings, err := b.canvasQueue.UpdateDefaultBatch(batchCount, batchSize)
 	if err != nil {
 		log.Printf("error updating batch settings: %v", err)
 
@@ -749,7 +748,7 @@ func (b *botImpl) processInvisionBatchSetting(s *discordgo.Session, i *discordgo
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
-			Content:    "Choose defaults settings for the invision command:",
+			Content:    "Choose defaults settings for the canvas command:",
 			Components: messageComponents,
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"kinshi_vision_bot/databases/sqlite"
 	"kinshi_vision_bot/discord_bot"
-	"kinshi_vision_bot/invision_queue"
+	"kinshi_vision_bot/canvas_queue"
 	"kinshi_vision_bot/repositories/default_settings"
 	"kinshi_vision_bot/repositories/image_generations"
 	"kinshi_vision_bot/stable_diffusion_api"
@@ -26,7 +26,7 @@ func getEnvVar(key, defaultValue string) string {
 }
 
 var (
-	invisionCommand    = flag.String("invision", "invision", "Invision command name. Default is \"invision\"")
+	canvasCommand      = flag.String("canvas", "canvas", "Canvas command name. Default is \"canvas\"")
 	removeCommandsFlag = flag.Bool("remove", false, "Delete all commands when bot exits")
 	devModeFlag        = flag.Bool("dev", false, "Start in development mode, using \"dev_\" prefixed commands instead")
 )
@@ -64,8 +64,8 @@ func main() {
 		log.Fatal("API host is required")
 	}
 
-	if invisionCommand == nil || *invisionCommand == "" {
-		log.Fatalf("Invision command flag is required")
+	if canvasCommand == nil || *canvasCommand == "" {
+		log.Fatalf("Canvas command flag is required")
 	}
 
 	devMode := false
@@ -106,22 +106,22 @@ func main() {
 		log.Fatalf("Failed to create default settings repository: %v", err)
 	}
 
-	invisionQueue, err := invision_queue.New(invision_queue.Config{
+	canvasQueue, err := canvas_queue.New(canvas_queue.Config{
 		StableDiffusionAPI:  stableDiffusionAPI,
 		ImageGenerationRepo: generationRepo,
 		DefaultSettingsRepo: defaultSettingsRepo,
 		BlockedKeywords:     blockedKeywords,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create invision queue: %v", err)
+		log.Fatalf("Failed to create canvas queue: %v", err)
 	}
 
 	bot, err := discord_bot.New(discord_bot.Config{
 		DevelopmentMode: devMode,
 		BotToken:        botToken,
 		GuildID:         guildID,
-		InvisionQueue:   invisionQueue,
-		InvisionCommand: *invisionCommand,
+		CanvasQueue:     canvasQueue,
+		CanvasCommand:   *canvasCommand,
 		RemoveCommands:  removeCommands,
 	})
 	if err != nil {


### PR DESCRIPTION
- Updated imports to use canvas_queue instead of invision_queue.
- Renamed variables and functions related to invision to canvas equivalents.
- Adjusted command strings and responses to reflect the canvas theme.
- Modified bot initialization to include canvas command and queue.
- Ensured all references to invision are replaced with canvas throughout the codebase.